### PR TITLE
Add avaje-nima-htmx module

### DIFF
--- a/avaje-nima-generator/pom.xml
+++ b/avaje-nima-generator/pom.xml
@@ -39,5 +39,9 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jstach</groupId>
+      <artifactId>jstachio-apt</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/avaje-nima-htmx/pom.xml
+++ b/avaje-nima-htmx/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.avaje</groupId>
+    <artifactId>avaje-nima-parent</artifactId>
+    <version>1.2-RC3</version>
+  </parent>
+
+  <artifactId>avaje-nima-htmx</artifactId>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <surefire.useModulePath>false</surefire.useModulePath>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-nima</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-htmx-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-htmx-nima</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach</groupId>
+      <artifactId>jstachio</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.helidon.webserver</groupId>
+      <artifactId>helidon-webserver-static-content</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-spi-service</artifactId>
+      <version>2.10</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/avaje-nima-htmx/src/main/java/io/avaje/htmx/nima/jstache/DefaultTemplateProvider.java
+++ b/avaje-nima-htmx/src/main/java/io/avaje/htmx/nima/jstache/DefaultTemplateProvider.java
@@ -1,0 +1,25 @@
+package io.avaje.htmx.nima.jstache;
+
+import io.avaje.htmx.nima.TemplateContentCache;
+import io.avaje.htmx.nima.TemplateRender;
+import io.avaje.inject.BeanScopeBuilder;
+import io.avaje.inject.spi.InjectPlugin;
+import io.avaje.spi.ServiceProvider;
+
+/**
+ * Plugin for avaje inject that provides a default TemplateRender instance.
+ */
+@ServiceProvider
+public final class DefaultTemplateProvider implements InjectPlugin {
+
+  @Override
+  public Class<?>[] provides() {
+    return new Class<?>[]{TemplateRender.class, TemplateContentCache.class};
+  }
+
+  @Override
+  public void apply(BeanScopeBuilder builder) {
+    builder.provideDefault(null, TemplateRender.class, JStacheTemplateRender::new);
+    builder.provideDefault(null, TemplateContentCache.class, SimpleContentCache::new);
+  }
+}

--- a/avaje-nima-htmx/src/main/java/io/avaje/htmx/nima/jstache/JStacheTemplateRender.java
+++ b/avaje-nima-htmx/src/main/java/io/avaje/htmx/nima/jstache/JStacheTemplateRender.java
@@ -1,0 +1,12 @@
+package io.avaje.htmx.nima.jstache;
+
+import io.avaje.htmx.nima.TemplateRender;
+import io.jstach.jstachio.JStachio;
+
+public final class JStacheTemplateRender implements TemplateRender {
+
+  @Override
+  public String render(Object viewModel) {
+    return JStachio.render(viewModel);
+  }
+}

--- a/avaje-nima-htmx/src/main/java/io/avaje/htmx/nima/jstache/SimpleContentCache.java
+++ b/avaje-nima-htmx/src/main/java/io/avaje/htmx/nima/jstache/SimpleContentCache.java
@@ -1,0 +1,31 @@
+package io.avaje.htmx.nima.jstache;
+
+import io.avaje.htmx.nima.TemplateContentCache;
+import io.helidon.webserver.http.ServerRequest;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SimpleContentCache implements TemplateContentCache {
+
+  private final ConcurrentHashMap<String,String> localCache = new ConcurrentHashMap<>();
+
+  @Override
+  public String key(ServerRequest req) {
+    return req.requestedUri().path().rawPath();
+  }
+
+  @Override
+  public String key(ServerRequest req, Object formParams) {
+    return req.requestedUri().path().rawPath() + formParams;
+  }
+
+  @Override
+  public String content(String key) {
+    return localCache.get(key);
+  }
+
+  @Override
+  public void contentPut(String key, String content) {
+    localCache.put(key, content);
+  }
+}

--- a/avaje-nima-htmx/src/main/java/module-info.java
+++ b/avaje-nima-htmx/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module io.avaje.nima.htmx {
+
+  exports io.avaje.htmx.nima.jstache;
+
+  requires transitive io.avaje.htmx.nima;
+  requires transitive io.helidon.webserver;
+  requires transitive io.jstach.jstachio;
+  requires transitive io.avaje.inject;
+  requires static io.avaje.spi;
+
+  provides io.avaje.inject.spi.InjectExtension with io.avaje.htmx.nima.jstache.DefaultTemplateProvider;
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,16 @@
     <avaje.prisms.version>1.39</avaje.prisms.version>
     <ebean.version>15.9.0</ebean.version>
     <helidon.version>4.2.0</helidon.version>
+    <jstachio.version>1.3.7</jstachio.version>
   </properties>
 
   <modules>
     <module>avaje-nima</module>
+    <module>avaje-nima-htmx</module>
     <module>avaje-nima-generator</module>
     <module>avaje-nima-test</module>
   </modules>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -83,6 +86,26 @@
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
+        <artifactId>avaje-http-client-generator</artifactId>
+        <version>${avaje.http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-http-helidon-generator</artifactId>
+        <version>${avaje.http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-htmx-api</artifactId>
+        <version>${avaje.http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-htmx-nima</artifactId>
+        <version>${avaje.http.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.avaje</groupId>
         <artifactId>avaje-inject</artifactId>
         <version>${avaje.inject.version}</version>
       </dependency>
@@ -105,16 +128,6 @@
         <groupId>io.avaje</groupId>
         <artifactId>avaje-validator</artifactId>
         <version>${avaje.validator.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.avaje</groupId>
-        <artifactId>avaje-http-client-generator</artifactId>
-        <version>${avaje.http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.avaje</groupId>
-        <artifactId>avaje-http-helidon-generator</artifactId>
-        <version>${avaje.http.version}</version>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
@@ -148,8 +161,23 @@
         <version>${avaje.spi.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio</artifactId>
+        <version>${jstachio.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-apt</artifactId>
+        <version>${jstachio.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-nima</artifactId>
+        <version>1.2-RC3</version>
+      </dependency>
+      <dependency>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-nima-htmx</artifactId>
         <version>1.2-RC3</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This is basically a composite of all the dependencies we need for nima + htmx + jstache

This also moves the DefaultTemplateProvider and JStacheTemplateRender to this module (likely to remove them from avaje-http).