### PR TITLE
nima test - support injecting HttpClient.Builder and WebServer

### DIFF
--- a/test-avaje-nima/src/main/java/org/example/web/HelloController.java
+++ b/test-avaje-nima/src/main/java/org/example/web/HelloController.java
@@ -32,8 +32,7 @@ public class HelloController {
 
   @Get("/metrics")
   String asJson() {
-    String asJson = Metrics.collectAsJson().asJson();
-    return asJson;
+    return Metrics.collectAsJson().asJson();
   }
 
   @Json

--- a/test-avaje-nima/src/test/java/org/example/InjectClientsTest.java
+++ b/test-avaje-nima/src/test/java/org/example/InjectClientsTest.java
@@ -1,0 +1,49 @@
+package org.example;
+
+import io.avaje.http.client.HttpClient;
+import io.avaje.inject.test.InjectTest;
+import io.helidon.webserver.WebServer;
+import jakarta.inject.Inject;
+import org.example.web.HelloControllerTestAPI;
+import org.junit.jupiter.api.Test;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@InjectTest
+class InjectClientsTest {
+
+  @Inject
+  HelloControllerTestAPI helloControllerTestAPI;
+
+  @Inject
+  HttpClient httpClient;
+
+  @Inject
+  HttpClient.Builder httpClientBuilder;
+
+  @Inject
+  WebServer webServer;
+
+  @Test
+  void test() {
+
+    assertThat(webServer).isNotNull();
+    assertThat(webServer.port()).isNotEqualTo(0);
+    assertThat(httpClient).isNotNull();
+    assertThat(httpClientBuilder).isNotNull();
+    assertThat(helloControllerTestAPI).isNotNull();
+
+    HttpResponse<String> res = helloControllerTestAPI.hello();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("hello world");
+
+    var res2 = httpClient.request().GET().asString();
+    assertThat(res2.statusCode()).isEqualTo(200);
+    assertThat(res2.body()).isEqualTo("hello world");
+
+    var res3 = httpClientBuilder.build().request().GET().asString();
+    assertThat(res3.statusCode()).isEqualTo(200);
+    assertThat(res3.body()).isEqualTo("hello world");
+  }
+}


### PR DESCRIPTION
The use case when we need to inject a HttpClient.Builder is when we have a test that either needs an additional RequestIntercept (or the opposite).

Also support injecting WebServer such that a test can access that if needed.