### PR TITLE
Add shutdownDelay (Due to Helidon bug)

### DIFF
--- a/avaje-nima/src/main/java/io/avaje/nima/DNimaBuilder.java
+++ b/avaje-nima/src/main/java/io/avaje/nima/DNimaBuilder.java
@@ -24,7 +24,8 @@ final class DNimaBuilder implements Nima.Builder {
   private int maxTcpConnections = Config.getInt("server.maxTcpConnections", 0);
   private long maxPayloadSize = Config.getLong("server.maxPayloadSize", 0);
   // private boolean shutdownHook = Config.getBool("server.shutdownHook", false);
-  private long shutdownGraceMillis = Config.getInt("server.shutdownGraceMillis", 0);
+  private long shutdownGraceMillis = Config.getLong("server.shutdownGraceMillis", 0);
+  private long shutdownDelay = Config.getLong("server.shutdownDelay", 0);
 
   private boolean health = Config.getBool("server.health", true);
 
@@ -76,6 +77,12 @@ final class DNimaBuilder implements Nima.Builder {
   @Override
   public Nima.Builder shutdownGraceMillis(long shutdownGraceMillis) {
     this.shutdownGraceMillis = shutdownGraceMillis;
+    return this;
+  }
+
+  @Override
+  public Nima.Builder shutdownDelay(long shutdownDelay) {
+    this.shutdownDelay = shutdownDelay;
     return this;
   }
 
@@ -161,6 +168,7 @@ final class DNimaBuilder implements Nima.Builder {
     configBuilder.addRouting(routeBuilder);
     configBuilder.port(port);
     configConsumers.forEach(b -> b.accept(configBuilder));
+    lifecycle.shutdownDelay(shutdownDelay);
     return new DNima(beanScope, new DWebServer(configBuilder.build(), lifecycle));
   }
 

--- a/avaje-nima/src/main/java/io/avaje/nima/Nima.java
+++ b/avaje-nima/src/main/java/io/avaje/nima/Nima.java
@@ -99,6 +99,14 @@ public interface Nima {
     Builder shutdownGraceMillis(long shutdownGraceMillis);
 
     /**
+     * Set a shutdown delay in milliseconds.
+     *
+     * <p>This delay is used to wait for active requests to complete before shutting down the server.
+     * @param shutdownDelayMillis The delay in milliseconds before the server is shut down
+     */
+    Builder shutdownDelay(long shutdownDelayMillis);
+
+    /**
      * Register a Runnable to run on shutdown of the server with ordering.
      *
      * <p>The callbacks are executed with order from low to high (0 means run first).

--- a/avaje-nima/src/test/java/io/avaje/nima/NimaTest.java
+++ b/avaje-nima/src/test/java/io/avaje/nima/NimaTest.java
@@ -45,6 +45,7 @@ class NimaTest {
       .maxPayloadSize(4_000)
       .maxTcpConnections(200)
       .shutdownGraceMillis(5_000)
+      .shutdownDelay(200)
       .build()
       .start();
 


### PR DESCRIPTION
There is a regression bug in Helidon that means it isn't performing a graceful shutdown. Refer: https://github.com/helidon-io/helidon/issues/10156

A less than ideal workaround is to add in a shutdown delay. This will not be required once a fix is applied in Helidon, but we may want to keep this shutdownDelay support just in case.