### PR TITLE
Log when "Initiating shutdown"

### DIFF
--- a/avaje-nima/src/main/java/io/avaje/nima/DLifecycle.java
+++ b/avaje-nima/src/main/java/io/avaje/nima/DLifecycle.java
@@ -100,6 +100,7 @@ final class DLifecycle implements AppLifecycle {
       if (status == STOPPED) {
         log.log(Level.INFO, "already stopped");
       } else {
+        log.log(Level.INFO, "Initiating shutdown");
         invokeCallbacks(STOPPING);
         if (shutdownDelay > 0) {
           LockSupport.parkNanos(Duration.ofMillis(shutdownDelay).toNanos());


### PR DESCRIPTION
This is so that we can see any shutdown delay explicitly in logs