### PR TITLE
Change avaje-nima-opentelemetry removing dependency on opentelemetry-instrumentation-api-incubator

### DIFF
--- a/avaje-nima-opentelemetry/pom.xml
+++ b/avaje-nima-opentelemetry/pom.xml
@@ -59,11 +59,6 @@
       <version>${otel.instrumentation.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-instrumentation-api-incubator</artifactId>
-      <version>${otel.instrumentation.version}-alpha</version>
-    </dependency>
-    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
       <version>1.0.0</version>

--- a/avaje-nima-opentelemetry/src/main/java/io/avaje/nima/opentelemetry/InstrumenterBuilder.java
+++ b/avaje-nima-opentelemetry/src/main/java/io/avaje/nima/opentelemetry/InstrumenterBuilder.java
@@ -3,12 +3,17 @@ package io.avaje.nima.opentelemetry;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpServerInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerMetrics;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanStatusExtractor;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,6 +26,7 @@ import java.util.function.UnaryOperator;
 final class InstrumenterBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.avaje.nima.helidon";
+  private static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.37.0";
 
   private final List<AttributesExtractor<ServerRequest, ServerResponse>> attributesExtractors = new ArrayList<>();
   private Collection<String> capturedRequestHeaders;
@@ -94,15 +100,24 @@ final class InstrumenterBuilder {
   }
 
   Instrumenter<ServerRequest, ServerResponse> build(OpenTelemetry openTelemetry) {
-    DefaultHttpServerInstrumenterBuilder<ServerRequest, ServerResponse> builder =
-      DefaultHttpServerInstrumenterBuilder.create(
-        INSTRUMENTATION_NAME,
-        openTelemetry,
-        new HelidonAttributesGetter(),
-        new HelidonRequestGetter());
+    var attributesGetter = new HelidonAttributesGetter();
+    var instrumenterBuilder = Instrumenter.<ServerRequest, ServerResponse>builder(
+      openTelemetry,
+      INSTRUMENTATION_NAME,
+      spanNameExtractor(attributesGetter))
+      .setSpanStatusExtractor(spanStatusExtractor(attributesGetter))
+      .addAttributesExtractor(httpAttributesExtractor(attributesGetter))
+      .addContextCustomizer(routeCustomizer(attributesGetter))
+      .addOperationMetrics(HttpServerMetrics.get())
+      .setSchemaUrl(SCHEMA_URL);
     for (var extractor : attributesExtractors) {
-      builder.addAttributesExtractor(extractor);
+      instrumenterBuilder.addAttributesExtractor(extractor);
     }
+    return instrumenterBuilder.buildServerInstrumenter(new HelidonRequestGetter());
+  }
+
+  private AttributesExtractor<ServerRequest, ServerResponse> httpAttributesExtractor(HelidonAttributesGetter attributesGetter) {
+    var builder = HttpServerAttributesExtractor.builder(attributesGetter);
     if (capturedRequestHeaders != null) {
       builder.setCapturedRequestHeaders(capturedRequestHeaders);
     }
@@ -112,12 +127,28 @@ final class InstrumenterBuilder {
     if (knownMethods != null) {
       builder.setKnownMethods(knownMethods);
     }
-    if (spanNameExtractorCustomizer != null) {
-      builder.setSpanNameExtractorCustomizer(spanNameExtractorCustomizer);
-    }
-    if (spanStatusExtractorCustomizer != null) {
-      builder.setSpanStatusExtractorCustomizer(spanStatusExtractorCustomizer);
+    return builder.build();
+  }
+
+  private ContextCustomizer<ServerRequest> routeCustomizer(HelidonAttributesGetter attributesGetter) {
+    var builder = HttpServerRoute.builder(attributesGetter);
+    if (knownMethods != null) {
+      builder.setKnownMethods(knownMethods);
     }
     return builder.build();
+  }
+
+  private SpanNameExtractor<ServerRequest> spanNameExtractor(HelidonAttributesGetter attributesGetter) {
+    var builder = HttpSpanNameExtractor.builder(attributesGetter);
+    if (knownMethods != null) {
+      builder.setKnownMethods(knownMethods);
+    }
+    var extractor = builder.build();
+    return spanNameExtractorCustomizer != null ? spanNameExtractorCustomizer.apply(extractor) : extractor;
+  }
+
+  private SpanStatusExtractor<ServerRequest, ServerResponse> spanStatusExtractor(HelidonAttributesGetter attributesGetter) {
+    var extractor = HttpSpanStatusExtractor.create(attributesGetter);
+    return spanStatusExtractorCustomizer != null ? spanStatusExtractorCustomizer.apply(extractor) : extractor;
   }
 }

--- a/avaje-nima-opentelemetry/src/main/java/module-info.java
+++ b/avaje-nima-opentelemetry/src/main/java/module-info.java
@@ -6,7 +6,6 @@ module io.avaje.nima.opentelemetry {
   requires transitive io.opentelemetry.api;
   requires transitive io.opentelemetry.context;
   requires transitive io.opentelemetry.instrumentation_api;
-  requires io.opentelemetry.instrumentation_api_incubator;
   requires org.slf4j;
   requires static org.jspecify;
 }

--- a/avaje-nima-opentelemetry/src/test/java/io/avaje/nima/opentelemetry/InstrumenterBuilderTest.java
+++ b/avaje-nima-opentelemetry/src/test/java/io/avaje/nima/opentelemetry/InstrumenterBuilderTest.java
@@ -1,0 +1,39 @@
+package io.avaje.nima.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InstrumenterBuilderTest {
+
+  @Test
+  void buildSupportsStableHttpServerComposition() {
+    var spanNameCustomized = new AtomicBoolean();
+    var spanStatusCustomized = new AtomicBoolean();
+
+    var instrumenter = new InstrumenterBuilder()
+      .addAttributesExtractor(AttributesExtractor.constant(AttributeKey.stringKey("extra"), "value"))
+      .setCapturedRequestHeaders(List.of("x-request-id"))
+      .setCapturedResponseHeaders(List.of("content-type"))
+      .setKnownMethods(List.of("GET", "PROPFIND"))
+      .setSpanNameExtractorCustomizer(extractor -> {
+        spanNameCustomized.set(true);
+        return extractor;
+      })
+      .setSpanStatusExtractorCustomizer(extractor -> {
+        spanStatusCustomized.set(true);
+        return extractor;
+      })
+      .build(OpenTelemetry.noop());
+
+    assertThat(instrumenter).isNotNull();
+    assertThat(spanNameCustomized).isTrue();
+    assertThat(spanStatusCustomized).isTrue();
+  }
+}


### PR DESCRIPTION
This dependency is an ALPHA release version and we can pretty easily inline the related code instead and hence remove the dependency.